### PR TITLE
Adding `.gitattributes` file to customize GitHub's Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 api/gen/** linguist-generated
 docs/** linguist-generated
+deployments/**.yaml linguist-language=yaml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+api/gen/** linguist-generated
+docs/** linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# ignore generated protbuf files
 api/gen/** linguist-generated
-docs/** linguist-generated
-deployments/**.yaml linguist-language=yaml
+# ignore documentation
+docs/** linguist-documentation


### PR DESCRIPTION
This resolves #3 by added linguist tags to the `.gitattributes` file to ignore documentation and generated code.