### PR TITLE
Updating local infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION=1.19
-ARG ALPINE_VERSION=3.17
+ARG GO_VERSION=1.21
+ARG ALPINE_VERSION=3.18
 
 # This layer builds the binary
 FROM golang:${GO_VERSION} AS builder

--- a/examples/go/pubsub/local.yaml
+++ b/examples/go/pubsub/local.yaml
@@ -6,23 +6,16 @@ configMap:
   domain: core
   env: local
   postgres:
-    url: postgres://admin:admin@localhost:5434/dev?sslmode=disable
-    # url: postgres://test:test@localhost:5434/dev?sslmode=disable
+    url: postgres://admin:admin@localhost:5432/postgres?sslmode=disable
     database: registry
   mongo:
     url: mongodb://admin:admin@localhost:27017
-    # url: mongodb://test:test@localhost:27017
   amqp:
     url: 'amqp://guest:guest@localhost:5672'
-    # url: 'amqp://test:test@localhost:5672'
   vault:
     url: http://localhost:8200
   nats:
     url: nats://localhost:4222
-  # registry is the only service which defines ports in local.yaml
-  # all other services request ports from the registry service itself
-  httpPort: 35000
-  grpcPort: 35001
 
   # secretsOverrides are values to override using the provided secrets client
   # secretsOverrides:

--- a/services/core/eventer/v1/local.yaml
+++ b/services/core/eventer/v1/local.yaml
@@ -9,19 +9,16 @@ configMap:
   # options
   isDevMode: true
   disableTracer: true
-  registryServiceAddress: localhost:35001
+  registryServiceAddress: http://localhost:35001
 
   # infrastructure
   postgres:
-    url: postgres://admin:admin@localhost:5434/dev?sslmode=disable
-    # url: postgres://test:test@localhost:5434/dev?sslmode=disable
+    url: postgres://admin:admin@localhost:5432/postgres?sslmode=disable
     database: eventer
   mongo:
     url: mongodb://admin:admin@localhost:27017
-    # url: mongodb://test:test@localhost:27017
   rabbitmq:
     url: 'amqp://guest:guest@localhost:5672'
-    # url: 'amqp://test:test@localhost:5672'
   vault:
     url: http://localhost:8200
   nats:

--- a/services/core/registry/v1/local.yaml
+++ b/services/core/registry/v1/local.yaml
@@ -12,15 +12,12 @@ configMap:
 
   # infrastructure
   postgres:
-    url: postgres://admin:admin@localhost:5434/dev?sslmode=disable
-    # url: postgres://test:test@localhost:5434/dev?sslmode=disable
+    url: postgres://admin:admin@localhost:5432/postgres?sslmode=disable
     database: registry
   mongo:
     url: mongodb://admin:admin@localhost:27017
-    # url: mongodb://test:test@localhost:27017
   rabbitmq:
     url: 'amqp://guest:guest@localhost:5672'
-    # url: 'amqp://test:test@localhost:5672'
   vault:
     url: http://localhost:8200
   nats:

--- a/third_party/vault/postgres.yaml
+++ b/third_party/vault/postgres.yaml
@@ -1,4 +1,4 @@
 user: admin
 password: admin
 host: localhost
-port: 5434
+port: 5432

--- a/third_party/vault/vault.sh
+++ b/third_party/vault/vault.sh
@@ -3,6 +3,6 @@
 export VAULT_TOKEN=myroot
 export VAULT_ADDR=http://0.0.0.0:8200
 
-vault kv put -mount=secret core/database/postgres/registry url=postgres://admin:admin@localhost:5434/dev?sslmode=disable
+vault kv put -mount=secret core/database/postgres/registry url=postgres://admin:admin@localhost:5432/dev?sslmode=disable
 vault kv put -mount=secret core/database/mongo/registry url=mongodb://admin:admin@localhost:27017
 vault kv put -mount=secret core/messaging/rabbitmq/registry url=amqp://guest:guest@localhost:5672

--- a/tools/gctl/cmd/infra/clean.go
+++ b/tools/gctl/cmd/infra/clean.go
@@ -22,7 +22,7 @@ func Clean(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		output.Error(err)
 	}
-	err = dctl.RemoveContainerByName(ctx, rabbitContainer)
+	err = dctl.RemoveContainerByName(ctx, natsContainer)
 	if err != nil {
 		output.Error(err)
 	}

--- a/tools/gctl/cmd/infra/init.go
+++ b/tools/gctl/cmd/infra/init.go
@@ -1,13 +1,10 @@
 package infra
 
 import (
-	"path/filepath"
-
 	"gctl/docker"
 	"gctl/output"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func Init(cmd *cobra.Command, args []string) error {
@@ -17,18 +14,13 @@ func Init(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	rootPath := viper.GetString("config.root")
-
-	// build custom rabbitmq image
-	output.Println("Building custom RabbitMQ Docker image...")
-	fullPath := filepath.Join(rootPath, "third_party", "rabbitmq")
-	err = dctl.BuildImage(ctx, fullPath, rabbitImage)
+	// pull needed images
+	output.Println("Pulling NATS Docker image...")
+	err = dctl.PullImage(ctx, natsImage)
 	if err != nil {
 		output.Error(err)
 		return err
 	}
-
-	// pull needed images
 	output.Println("Pulling Mongo Docker image...")
 	err = dctl.PullImage(ctx, mongoImage)
 	if err != nil {

--- a/tools/gctl/cmd/infra/start.go
+++ b/tools/gctl/cmd/infra/start.go
@@ -17,13 +17,11 @@ var (
 )
 
 const (
-	mongoImage        = "mongo:6.0.3"
+	mongoImage        = "mongo:7.0.2"
 	mongoContainer    = "galactus-mongo"
-	postgresImage     = "postgres:14.4"
+	postgresImage     = "postgres:16.0"
 	postgresContainer = "galactus-postgres"
-	rabbitImage       = "rabbitmq:galactus"
-	rabbitContainer   = "galactus-rabbitmq"
-	hasuraImage       = "hasura/graphql-engine:v2.15.2"
+	hasuraImage       = "hasura/graphql-engine:v2.34.0"
 	hasuraContainer   = "galactus-hasura"
 	natsImage         = "nats:2.10.2"
 	natsContainer     = "galactus-nats"
@@ -46,7 +44,7 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 		Env: []string{
 			"POSTGRES_PASSWORD=admin",
 			"POSTGRES_USER=admin",
-			"POSTGRES_DB=dev",
+			"POSTGRES_DB=postgres",
 		},
 		ExposedPorts: map[nat.Port]struct{}{
 			"5432/tcp": {}},
@@ -56,7 +54,7 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 			"5432/tcp": []nat.PortBinding{
 				{
 					HostIP:   "0.0.0.0",
-					HostPort: "5434",
+					HostPort: "5432",
 				},
 			},
 		},
@@ -126,14 +124,15 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 		defer stop(context.Background(), dctl, id)
 	}
 
+	// wait for databases to start before starting hasura
 	time.Sleep(5 * time.Second)
 
 	// hasura
 	config = &container.Config{
 		Image: hasuraImage,
 		Env: []string{
-			"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://admin:admin@host.docker.internal:5434/dev",
-			"HASURA_GRAPHQL_DATABASE_URL=postgres://admin:admin@host.docker.internal:5434/dev",
+			"HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://admin:admin@host.docker.internal:5432/postgres",
+			"HASURA_GRAPHQL_DATABASE_URL=postgres://admin:admin@host.docker.internal:5432/postgres",
 			"HASURA_GRAPHQL_ENABLE_CONSOLE=true",
 			"HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup, http-log, webhook-log, websocket-log, query-log",
 			"HASURA_GRAPHQL_ENABLE_TELEMETRY=false",
@@ -167,7 +166,6 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 
 	return nil
 }
-
 
 func stop(ctx context.Context, dctl docker.DockerController, id string) {
 	err := dctl.StopContainer(ctx, id)

--- a/tools/gctl/cmd/infra/start.go
+++ b/tools/gctl/cmd/infra/start.go
@@ -25,6 +25,8 @@ const (
 	rabbitContainer   = "galactus-rabbitmq"
 	hasuraImage       = "hasura/graphql-engine:v2.15.2"
 	hasuraContainer   = "galactus-hasura"
+	natsImage         = "nats:2.10.2"
+	natsContainer     = "galactus-nats"
 )
 
 func Start(cmd *cobra.Command, args []string) (err error) {
@@ -97,32 +99,25 @@ func Start(cmd *cobra.Command, args []string) (err error) {
 		defer stop(context.Background(), dctl, id)
 	}
 
-	// rabbitmq
+	// nats
 	config = &container.Config{
-		Image: rabbitImage,
+		Image: natsImage,
 		Env:   []string{},
 		ExposedPorts: map[nat.Port]struct{}{
-			"15672/tcp": {},
-			"5672/tcp":  {},
+			"4222/tcp": {},
 		},
 	}
 	hostConfig = &container.HostConfig{
 		PortBindings: nat.PortMap{
-			"15672/tcp": []nat.PortBinding{
+			"4222/tcp": []nat.PortBinding{
 				{
 					HostIP:   "0.0.0.0",
-					HostPort: "15672",
-				},
-			},
-			"5672/tcp": []nat.PortBinding{
-				{
-					HostIP:   "0.0.0.0",
-					HostPort: "5672",
+					HostPort: "4222",
 				},
 			},
 		},
 	}
-	id, err = dctl.StartContainer(ctx, rabbitContainer, config, hostConfig, Follow)
+	id, err = dctl.StartContainer(ctx, natsContainer, config, hostConfig, Follow)
 	if err != nil {
 		output.Error(err)
 		return err

--- a/tools/gctl/cmd/infra/stop.go
+++ b/tools/gctl/cmd/infra/stop.go
@@ -27,7 +27,7 @@ func Stop(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		output.Error(err)
 	}
-	err = dctl.StopContainerByName(ctx, rabbitContainer)
+	err = dctl.StopContainerByName(ctx, natsContainer)
 	if err != nil {
 		output.Error(err)
 	}


### PR DESCRIPTION
Changes:
- Change default from RabbitMQ to NATS
- Update default postgres database from `dev` to `postgres`
- Update postgres database port from `5434` to `5432`